### PR TITLE
API and domain (data structure) types

### DIFF
--- a/minimal_cns/canisters/tld_operator/api_types.mo
+++ b/minimal_cns/canisters/tld_operator/api_types.mo
@@ -1,0 +1,42 @@
+import DomainTypes "../../common/data/domain/types";
+
+module {
+  public type LookupArgs = {
+    domain : Text;
+    recordType : Text;
+  };
+
+  public type LookupResponse = {
+    answers : [DomainTypes.DomainRecord];
+    additionals : [DomainTypes.DomainRecord];
+    authorities : [DomainTypes.DomainRecord];
+  };
+
+  type RegistrationControllerRole = {
+    #registrar;
+    #registrant;
+    #technical;
+    #administrative;
+  };
+
+  type RegistrationController = {
+    principal : Principal;
+    roles : [RegistrationControllerRole];
+  };
+
+  type RegistrationRecords = {
+    controller : [RegistrationController];
+    records : ?[DomainTypes.DomainRecord];
+  };
+
+  public type RegisterArgs = {
+    domain : Text;
+    principal : Principal;
+    records : RegistrationRecords;
+  };
+
+  public type RegisterResult = {
+    success : Bool;
+    message : ?Text;
+  };
+}

--- a/minimal_cns/canisters/tld_operator/lib.mo
+++ b/minimal_cns/canisters/tld_operator/lib.mo
@@ -1,3 +1,4 @@
+import APITypes "api_types";
 import Map "mo:base/Map";
 import Metrics "../../common/metrics";
 import Principal "mo:base/Principal";
@@ -15,18 +16,18 @@ actor TldOperator {
   stable var metricsStore : Metrics.LogStore = Metrics.newStore();
   let metrics = Metrics.CnsMetrics(metricsStore);
 
-  public shared func lookup(domain : Text, recordType : Text) : async Types.DomainLookup {
-    Queries.lookup(myTld, lookupAnswersMap, Metrics.CnsMetrics(metricsStore), domain, recordType);
+  public shared func lookup(args : APITypes.LookupArgs) : async APITypes.LookupResponse {
+    Queries.lookup(myTld, lookupAnswersMap, Metrics.CnsMetrics(metricsStore), args.domain, args.recordType);
   };
 
-  public shared ({ caller }) func register(domain : Text, records : Types.RegistrationRecords) : async (Types.RegisterResult) {
-    let domainLowercase : Text = Text.toLower(domain);
-    let (result, recordType) = Mutations.validateAndRegister(caller, myTld, lookupAnswersMap, domainLowercase, records);
+  public shared ({ caller }) func register(args: APITypes.RegisterArgs) : async (APITypes.RegisterResult) {
+    let domainLowercase : Text = Text.toLower(args.domain);
+    let (result, recordType) = Mutations.validateAndRegister(caller, myTld, lookupAnswersMap, domainLowercase, args.records);
     metrics.addEntry(metrics.makeRegisterEntry(domainLowercase, recordType, result.success));
     return result;
   };
 
-  public shared query ({ caller }) func get_metrics(period : Text) : async Result.Result<Metrics.MetricsData, Text> {
+  public shared query ({ caller }) func get_metrics({ period : Text }) : async Result.Result<Metrics.MetricsData, Text> {
     if (not Principal.isController(caller)) {
       return #err("Currently only a controller can get metrics");
     };

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -1,4 +1,6 @@
+import APITypes "api_types";
 import Types "../../common/cns_types";
+import DomainTypes "../../common/data/domain/types";
 import MetricsTypes "../../common/metrics";
 import Map "mo:base/Map";
 import Option "mo:base/Option";
@@ -11,8 +13,8 @@ module {
     metrics : MetricsTypes.CnsMetrics,
     domain : Text,
     recordType : Text
-  ) : Types.DomainLookup {
-    var answers : [Types.DomainRecord] = [];
+  ) : APITypes.LookupResponse {
+    var answers : [DomainTypes.DomainRecord] = [];
     let domainLowercase : Text = Text.toLower(domain);
 
     if (Text.endsWith(domainLowercase, #text myTld)) {

--- a/minimal_cns/common/cns_types.mo
+++ b/minimal_cns/common/cns_types.mo
@@ -1,9 +1,10 @@
 import NameRegistry "canister:name_registry";
+import DomainTypes "data/domain/types";
 import Text "mo:base/Text";
 import Principal "mo:base/Principal";
 
 module {
-  public type DomainRecord = NameRegistry.DomainRecord;
+  public type DomainRecord = DomainTypes.DomainRecord;
   public type DomainLookup = NameRegistry.DomainLookup;
 
   public type OperationResult = {

--- a/minimal_cns/common/data/domain/types.mo
+++ b/minimal_cns/common/data/domain/types.mo
@@ -1,0 +1,53 @@
+import Map "mo:base/Map";
+import StableBuffer "mo:stablebuffer/StableBuffer";
+
+module {
+  public type RecordName = Text;
+  /// DomainRecord represents a zone record item.
+  public type DomainRecord = {
+    /// The domain name, e.g. "mydomain.tld.", the name is required for all operations and must
+    /// end with a dot (.). Names have well defined size limits and must have the parts between
+    /// the dots or commonly called as labels with equal or less then 63 bytes and the entire
+    /// name must be under 255 bytes.
+    ///
+    /// Names are encoded in ascii and are case insensitive, but the canonical form is lowercase.
+    name : RecordName;
+    /// The record type refers to the classification or category of a specific record within the
+    /// system, e.g. "CID", "A", "CNAME", "TXT", "MX", "AAAA", "NC", "NS", "DNSKEY", "NSEC".
+    ///
+    /// Also, "ANY" is a reserved type that can only be used in lookups to retrieve all records of a domain.
+    ///
+    /// Record types can have maximum of 12 bytes, are encoded in ascii and are case insensitive,
+    record_type : Text;
+    /// The Time to Live (TTL) is a parameter in a record that specifies the amount of time for
+    /// which the record should be cached before being refreshed from the authoritative naming canister.
+    ///
+    /// This value must be set in seconds and the minimum value is 0 seconds, which means not cached.
+    /// Common values for TTL include 3600 seconds (1 hour), 86400 seconds (24 hours), or other intervals
+    /// based on specific needs.
+    ttl : Nat;
+    /// The record data in a domain record refers to the specific information associated with that record type.
+    /// Format of the data depends on the type of record to fit its purpose, but it must not exceed 2550 bytes.
+    data : Text;
+  };
+
+  // A lowercase domain name, e.g. "mydomain.tld.".
+  public type Domain = Text;
+
+  public type DomainRecordWithPrincipals = {
+    // The domain record.
+    record : DomainRecord;
+    // The list of principals that point to the domain.
+    principals : StableBuffer.StableBuffer<Principal>;
+  };
+
+  public type DomainRecordsMap = Map.Map<Domain, DomainRecordWithPrincipals>;
+  public type PrincipalToDomainIndex = Map.Map<Principal, Domain>;
+
+  public type DomainRecordsStore = {
+    // The map of domain to domain records and the principals that point to the domain.
+    domainToRecordsMap : DomainRecordsMap;
+    // Principal to domain that the principal points to.
+    principalToDomainIndex : PrincipalToDomainIndex;
+  };
+}


### PR DESCRIPTION
add in initial types for domain data structure, create file for canister API types and make arguments of type record for backwards compatibility