### PR TITLE
Add in domain data structure with SID (subnet) record support and reverse lookups

### DIFF
--- a/minimal_cns/canisters/tld_operator/api_types.mo
+++ b/minimal_cns/canisters/tld_operator/api_types.mo
@@ -24,7 +24,7 @@ module {
     roles : [RegistrationControllerRole];
   };
 
-  type RegistrationRecords = {
+  public type RegistrationRecords = {
     controller : [RegistrationController];
     records : ?[DomainTypes.DomainRecord];
   };

--- a/minimal_cns/canisters/tld_operator/lib.mo
+++ b/minimal_cns/canisters/tld_operator/lib.mo
@@ -1,43 +1,47 @@
 import APITypes "api_types";
 import Map "mo:base/Map";
+import Domain "../../common/data/domain";
 import Metrics "../../common/metrics";
 import Principal "mo:base/Principal";
 import Result "mo:base/Result";
+import { trap } "mo:base/Runtime";
 import Text "mo:base/Text";
-import Types "../../common/cns_types";
 import Mutations "mutations";
 import Queries "queries";
 
 actor TldOperator {
   let myTld = ".icp.";
-  type DomainRecordsMap = Map.Map<Text, Types.RegistrationRecords>;
-  stable var lookupAnswersMap : DomainRecordsMap = Map.empty();
+  stable let domainRecordsStore = Domain.initDomainRecordsStore();
 
   stable var metricsStore : Metrics.LogStore = Metrics.newStore();
   let metrics = Metrics.CnsMetrics(metricsStore);
 
+  // TODO: discuss metrics approach, using store vs. logs
   public shared func lookup(args : APITypes.LookupArgs) : async APITypes.LookupResponse {
-    Queries.lookup(myTld, lookupAnswersMap, Metrics.CnsMetrics(metricsStore), args.domain, args.recordType);
+    let result = Queries.lookup(myTld, domainRecordsStore, args.domain, args.recordType);
+    metrics.addEntry(metrics.makeLookupEntry(args.domain, args.recordType, result.answers != []));
+    return result;
   };
 
+  // TODO: discuss metrics approach, using store vs. logs
+  // TODO: discuss if the RegistrationRecords type with RegistrationController and RegistrationControllerRole is neeeded at this point?
   public shared ({ caller }) func register(args: APITypes.RegisterArgs) : async (APITypes.RegisterResult) {
-    let domainLowercase : Text = Text.toLower(args.domain);
-    let (result, recordType) = Mutations.validateAndRegister(caller, myTld, lookupAnswersMap, domainLowercase, args.records);
-    metrics.addEntry(metrics.makeRegisterEntry(domainLowercase, recordType, result.success));
+    if (not Principal.isController(caller)) trap("Not authorized");
+
+    let result = Mutations.register(domainRecordsStore, myTld, args.domain, args.principal, args.records);
+    metrics.addEntry(metrics.makeRegisterEntry(args.domain, "TODO", result.success));
     return result;
   };
 
   public shared query ({ caller }) func get_metrics({ period : Text }) : async Result.Result<Metrics.MetricsData, Text> {
-    if (not Principal.isController(caller)) {
-      return #err("Currently only a controller can get metrics");
-    };
-    return #ok(metrics.getMetrics(period, [("cidRecordsCount", Map.size(lookupAnswersMap))]));
+    if (not Principal.isController(caller)) trap("Not authorized");
+
+    #ok(metrics.getMetrics(period, [("cidRecordsCount", Map.size(domainRecordsStore.domainToRecordsMap))]));
   };
 
   public shared ({ caller }) func purge_metrics() : async Result.Result<Nat, Text> {
-    if (not Principal.isController(caller)) {
-      return #err("Currently only a controller can purge metrics");
-    };
+    if (not Principal.isController(caller)) trap("Not authorized");
+
     return #ok(metrics.purge());
   };
 };

--- a/minimal_cns/canisters/tld_operator/mutations.mo
+++ b/minimal_cns/canisters/tld_operator/mutations.mo
@@ -1,117 +1,92 @@
-import Types "../../common/cns_types";
-import Map "mo:base/Map";
+import APITypes "api_types";
+import Domain "../../common/data/domain";
+import DomainTypes "../../common/data/domain/types";
 import Result "mo:base/Result";
 import Text "mo:base/Text";
 import Principal "mo:base/Principal";
 import Option "mo:base/Option";
-import { trap } "mo:base/Runtime";
+import Iter "mo:base/Iter";
 
 module {
-  // In addition th the `RegisterResult` this helper returns the relevant record type,
-  // so that the caller can properly log the operation.
-  public func validateAndRegister(
-    caller : Principal,
-    myTld : Text,
-    lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
-    domainLowercase : Text,
-    records : Types.RegistrationRecords
-  ) : (Types.RegisterResult, Text) {
-    let (domainRecord, maybeRegistrant) = switch (validateRegistrationRecords(myTld, lookupAnswersMap, domainLowercase, records)) {
-      case (#ok(record, maybePrincipal)) { (record, maybePrincipal) };
-      case (#err(msg)) {
-        return (
-          {
-            success = false;
-            message = ?(msg);
-          },
-          "",
-        );
-      };
-    };
-    if (not Principal.isController(caller)) {
-      // Only subdomains of .test.icp are allowed for non-controllers
-      if (not Text.endsWith(domainLowercase, #text(".test" # myTld))) {
-        return (
-          {
-            success = false;
-            message = ?("Currently only a canister controller can register non-test " # myTld # "-domains, domain: " # domainLowercase # ", caller: " # Principal.toText(caller));
-          },
-          "",
-        );
-      };
-      // If the domain was registered previously, the caller must match the existing registrant.
-      switch (maybeRegistrant) {
-        case (null) {};
-        case (?registrant) {
-          if (registrant != caller) {
-            return (
-              {
-                success = false;
-                message = ?("Caller " # Principal.toText(caller) # " does not match the registrant " # Principal.toText(registrant));
-              },
-              "",
-            );
-          };
-        };
-      };
-    };
-    let registrationRecord = {
-      controller = [{
-        principal = caller;
-        roles = [#registrant];
-      }];
-      records = ?[domainRecord];
-    };
-    Map.add(lookupAnswersMap, Text.compare, domainLowercase, registrationRecord);
+  public func register(
+    domainRecordsStore: DomainTypes.DomainRecordsStore,
+    tld : Text,
+    domain : Text,
+    principal : Principal,
+    records : APITypes.RegistrationRecords
+  ) : APITypes.RegisterResult {
 
-    return (
-      {
-        success = true;
-        message = null;
-      },
-      Text.toUpper(domainRecord.record_type),
-    );
-  };
-
-    // Validates the records, and if the domain already exisits, extracts the registrant.
-  // If validation fails, returns an error message.
-  func validateRegistrationRecords(
-    myTld : Text,
-    lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
-    domainLowercase : Text, records : Types.RegistrationRecords) : Result.Result<(Types.DomainRecord, ?Principal), Text> {
     let domainRecords = Option.get(records.records, []);
     // TODO: remove the restriction of acceping exactly one domain record.
     if (domainRecords.size() != 1) {
-      return #err("Currently exactly one domain record must be specified.");
-    };
-    // TODO: remove the restriction of not setting the controller(s) explicitly.
-    if (records.controller.size() != 0) {
-      return #err("Currently no explicit controller setting is supported.");
-    };
-    let record : Types.DomainRecord = domainRecords[0];
-    let recordType = Text.toUpper(record.record_type);
-    if (not Text.endsWith(domainLowercase, #text myTld)) {
-      return #err("Unsupported TLD in domain " # domainLowercase # ", expected TLD=" # myTld);
-    };
-    if (domainLowercase != Text.toLower(record.name)) {
-      return #err("Inconsistent domain record, record.name: `" # record.name # "` doesn't match domain: " # domainLowercase);
-    };
-    if (recordType != "CID") {
-      return #err("Currently only CID-records can be registered");
-    };
-    // TODO: don't trap on invalid Principals.
-    let _ = Principal.fromText(record.data);
-
-    let maybeRegistrant : ?Principal = switch (Map.get(lookupAnswersMap, Text.compare, domainLowercase)) {
-      case (null) { null };
-      case (?records) {
-        if (records.controller.size() == 0) {
-          trap("Internal error: missing registration controller for " # domainLowercase);
-        } else {
-          ?records.controller[0].principal;
-        };
+      return {
+        success = false;
+        message = ?"Currently exactly one domain record must be specified.";
       };
     };
-    return #ok(Types.normalizedDomainRecord(record), maybeRegistrant);
+    let record : DomainTypes.DomainRecord = domainRecords[0];
+    let sanitizedDomain = Domain.sanitizeDomain(domain);
+
+    switch (validateRecord(tld, sanitizedDomain, principal, record)) {
+      case (#err(message)) return { success = false; message = ?message };
+      case (#ok) {};
+    };
+
+    Domain.addRecord(domainRecordsStore, sanitizedDomain, principal, record);
+
+    return {
+      success = true;
+      message = null;
+    };
+  };
+
+  // TODO: add more checks: validate domain name and all the fields of the domain record(s).
+  func validateRecord(tld : Text, domain : Text, principal : Principal, record : DomainTypes.DomainRecord) : Result.Result<(), Text> {
+    if (not Text.endsWith(domain, #text tld)) {
+      return #err("Unsupported TLD in domain " # domain # ", expected TLD=" # tld);
+    };
+
+    // Disallow someone to register a reverse domain
+    let parts = Iter.toArray(Text.split(domain, #char '.'));
+    if (parts.size() < 2) return #err("No domain present");
+    let secondToLastPart = parts[parts.size() - 2];
+    if (secondToLastPart == "reverse") return #err("This domain is reserved");
+
+    // Check that the domain matches the record name
+    if (domain != Text.toLower(record.name)) {
+      return #err("Inconsistent domain record, record.name: `" # record.name # "` doesn't match domain: " # domain);
+    };
+
+    switch (isCompatibleWithDomain(tld, record, principal, domain)) {
+      case (#ok) {};
+      case (#err(message)) return #err("Incompatible domain record: " # message);
+    };
+
+    #ok;
+  };
+
+  func isCompatibleWithDomain(tld : Text, record: DomainTypes.DomainRecord, principal : Principal, domain : Text) : Result.Result<(), Text> {
+    switch (record.record_type) {
+      case ("SID") {
+        let expectedEnding = ".subnet" # tld;
+        if (not Text.endsWith(domain, #text(expectedEnding))) return #err("Unsupported TLD in domain " # domain # ", expected TLD=" # expectedEnding);
+        let parts = Iter.toArray(Text.split(domain, #char '.'));
+        // Check that the principal is a valid subnet principal (self-authenticating)
+        let domainPrincipal = Principal.fromText(parts[0]);
+        if (domainPrincipal != principal) return #err("Domain principal does not match the provided principal");
+        if (not Principal.isSelfAuthenticating(principal)) return #err("Invalid subnet principal: " # parts[0]);
+
+        #ok;
+      };
+      case ("CID") {
+        if (not Text.endsWith(domain, #text(tld))) return #err("Unsupported TLD in domain " # domain # ", expected TLD=" # tld);
+        // Check that the principal is a valid canister principal (opaque)
+        if (not Principal.isCanister(principal)) return #err("Invalid canister principal: " # Principal.toText(principal));
+
+        #ok;
+      };
+
+      case _ return #err("Unsupported record type");
+    };
   };
 }

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -1,40 +1,78 @@
 import APITypes "api_types";
-import Types "../../common/cns_types";
 import DomainTypes "../../common/data/domain/types";
-import MetricsTypes "../../common/metrics";
-import Map "mo:base/Map";
-import Option "mo:base/Option";
 import Text "mo:base/Text";
+import Iter "mo:base/Iter";
+import Principal "mo:base/Principal";
+import Domain "../../common/data/domain";
 
 module {
   public func lookup(
-    myTld : Text,
-    lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
-    metrics : MetricsTypes.CnsMetrics,
+    tld : Text,
+    domainRecordsStore : DomainTypes.DomainRecordsStore,
     domain : Text,
-    recordType : Text
+    recordType : Text,
   ) : APITypes.LookupResponse {
-    var answers : [DomainTypes.DomainRecord] = [];
-    let domainLowercase : Text = Text.toLower(domain);
+    // sanitize the input domain
+    let sanitizedDomain = Domain.sanitizeDomain(domain);
 
-    if (Text.endsWith(domainLowercase, #text myTld)) {
-      switch (Text.toUpper(recordType)) {
-        case ("CID") {
-          let maybeRecords : ?Types.RegistrationRecords = Map.get(lookupAnswersMap, Text.compare, domainLowercase);
-          answers := switch (maybeRecords) {
-            case (null) { [] };
-            case (?records) {
-              let domainRecords = Option.get(records.records, []);
-              if (domainRecords.size() == 0) { [] } else { [domainRecords[0]] };
-            };
-          };
-        };
-        case _ {};
+    // Ensure the lookup domain matches the TLD and the record type is supported.
+    if (
+      not Text.endsWith(sanitizedDomain, #text tld) or
+      Domain.isRecordTypeSupported(recordType)
+    ) {
+      return { answers = []; additionals = []; authorities = [] };
+    };
+
+    if (Text.toUpper(recordType) == "PTR") return reverseLookup(domainRecordsStore, sanitizedDomain);
+
+    let answers = switch(Domain.getRecordByDomain(domainRecordsStore.domainToRecordsMap, sanitizedDomain)) {
+      case null { [] };
+      case (?record) {
+        if (Text.toUpper(record.record_type) != Text.toUpper(recordType)) { [] }
+        else { [record] }
       };
     };
-    metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, answers != []));
+
     {
-      answers = answers;
+      answers;
+      additionals = [];
+      authorities = [];
+    };
+  };
+
+  // Reverse lookups have the format <principal>.reverse.<tld>
+  // In this case, we expect the <principal> to be a valid principal.
+  public func reverseLookup(
+    domainRecordsStore: DomainTypes.DomainRecordsStore,
+    domain : Text,
+  ) : APITypes.LookupResponse {
+    // split the domain into parts, based on "."
+    let parts = Iter.toArray(Text.split(domain, #char '.'));
+    // expect there to be exactly 3 parts: <principal>, reverse, <tld>
+    // TODO: Is this assumption correct?
+    if (parts.size() != 3) {
+      return { answers = []; additionals = []; authorities = [] };
+    };
+
+    let principalText = parts[0];
+    // check if the first part is a valid principal - will trap if not
+    // TODO: perform this check without trapping
+    let principal = Principal.fromText(principalText);
+
+    // check if the second part is "reverse"
+    if (parts[1] != "reverse") {
+      return { answers = []; additionals = []; authorities = [] };
+    };
+
+    // look up the domain record by the principal
+
+    let answers = switch(Domain.getRecordByPrincipal(domainRecordsStore, principal)) {
+      case null { [] };
+      case (?record) { [record] };
+    };
+
+    {
+      answers;
       additionals = [];
       authorities = [];
     };

--- a/minimal_cns/common/data/domain/lib.mo
+++ b/minimal_cns/common/data/domain/lib.mo
@@ -1,0 +1,151 @@
+import Map "mo:base/Map";
+import Text "mo:base/Text";
+import Principal "mo:base/Principal";
+import StableBuffer "mo:stablebuffer/StableBuffer";
+import { trimWhitespace; isAlphaNumericOr } "../../sanitize";
+import Types "types";
+
+module {
+  public func initDomainRecordsStore() : Types.DomainRecordsStore {
+    {
+      domainToRecordsMap = Map.empty<Types.Domain, Types.DomainRecordWithPrincipals>();
+      principalToDomainIndex = Map.empty<Principal, Types.Domain>();
+    }
+  };
+
+  // returns the sanitized domain name
+  // if invalid, returns the empty string
+  public func sanitizeDomain(domain : Text) : Text {
+    // size check
+    if (Text.size(domain) > 40) return "";
+    // trim whitespace
+    let trimmed = trimWhitespace(domain);
+    // character check
+    for (char in trimmed.chars()) {
+      if (not isAlphaNumericOr(
+        char,
+        func(c: Char) : Bool = c == '-' or c == '.',
+      )) return ""; 
+    };
+    // domain name must start and end with an alphanumeric character
+    if (
+      Text.startsWith(trimmed, #char('-')) or
+      Text.endsWith(trimmed, #char('-')) or
+      Text.startsWith(trimmed, #char('.')) or
+      Text.endsWith(trimmed, #char('.'))
+    ) return "";
+
+    // Lowercase the domain name
+    Text.toLower(trimmed);
+  };
+
+  // Note: "PTR" records are not explicitly added to the domainToRecordsMap
+  // instead, they are implied through the principalToDomainIndex
+  public func addRecord(
+    { domainToRecordsMap; principalToDomainIndex }: Types.DomainRecordsStore,
+    domain : Types.Domain,
+    principal : Principal,
+    record : Types.DomainRecord
+  ) : () {
+    // add main entry
+    addToDomainRecordsMap(domainToRecordsMap, domain, record, principal);
+    // add to domain to principal index
+    Map.add(principalToDomainIndex, Principal.compare, principal, domain);
+  };
+
+  // Removes the domain record for the given principal
+  // If there are no more prinicpals that point to the given domain record, it is removed
+  public func removePrincipalDomainLink(
+    { domainToRecordsMap; principalToDomainIndex }: Types.DomainRecordsStore,
+    principal : Principal,
+    domain : Types.Domain
+  ) : () {
+    // remove from the main domain to records map
+    removePrincipalFromDomainRecordsMap(domainToRecordsMap, domain, principal);
+    // remove from the principal to domain index
+    Map.remove(principalToDomainIndex, Principal.compare, principal);
+  };
+
+  public func getRecordByDomain(
+    domainToRecordsMap : Types.DomainRecordsMap,
+    domain : Types.Domain
+  ) : ?Types.DomainRecord {
+    switch(Map.get(domainToRecordsMap, Text.compare, domain)) {
+      case null { null };
+      case (?{ record }) ?record;
+    };
+  };
+
+  public func getRecordByPrincipal(
+    { domainToRecordsMap; principalToDomainIndex } : Types.DomainRecordsStore,
+    principal : Principal
+  ) : ?Types.DomainRecord {
+    switch (Map.get(principalToDomainIndex, Principal.compare, principal)) {
+      case null { null };
+      case (?domain) { getRecordByDomain(domainToRecordsMap, domain) };
+    }
+  };
+
+  public func isRecordTypeSupported(recordType : Text) : Bool {
+    let recordTypeUpper = Text.toUpper(recordType);
+
+    recordTypeUpper == "CID" or
+    recordTypeUpper == "SID" or
+    recordTypeUpper == "PTR"
+  };
+
+  public func normalizedDomainRecord(record : Types.DomainRecord) : Types.DomainRecord {
+    return {
+      name = Text.toLower(record.name);
+      record_type = Text.toUpper(record.record_type);
+      ttl = record.ttl;
+      data = record.data;
+    };
+  };
+
+  func addToDomainRecordsMap(
+    domainToRecordsMap : Types.DomainRecordsMap,
+    domain : Types.Domain,
+    record : Types.DomainRecord,
+    principal : Principal
+  ) : () {
+    let domainPrincipals = switch (Map.get(domainToRecordsMap, Text.compare, domain)) {
+      case null { StableBuffer.init<Principal>() };
+      case (?existingRecord) { existingRecord.principals };
+    };
+    // Only add the principal if it is not already in the list
+    if (not StableBuffer.contains(domainPrincipals, principal, Principal.equal)) {
+      StableBuffer.add(domainPrincipals, principal);
+    };
+    Map.add(
+      domainToRecordsMap,
+      Text.compare,
+      domain,
+      {
+        record;
+        principals = domainPrincipals;
+      }
+    );
+  };
+
+  func removePrincipalFromDomainRecordsMap(
+    domainToRecordsMap : Types.DomainRecordsMap,
+    domain : Types.Domain,
+    principal : Principal
+  ) : () {
+    let principals = switch (Map.get(domainToRecordsMap, Text.compare, domain)) {
+      case null return; 
+      case (?existingRecord) { existingRecord.principals };
+    };
+
+    switch(StableBuffer.indexOf(principal, principals, Principal.equal)) {
+      case null return;
+      case (?deleteIndex) { ignore StableBuffer.remove(principals, deleteIndex) };
+    };
+
+    // If the existing record has no principals left, remove the record
+    if (StableBuffer.isEmpty(principals)) {
+      Map.remove(domainToRecordsMap, Text.compare, domain);
+    };
+  };
+}

--- a/minimal_cns/common/sanitize.mo
+++ b/minimal_cns/common/sanitize.mo
@@ -1,0 +1,21 @@
+import Text "mo:base/Text";
+import Char "mo:base/Char";
+
+
+module {
+  public func trimWhitespace(text : Text) : Text {
+    Text.trimEnd(Text.trimStart(text, #char(' ')), #char(' '));
+  };
+
+  public func isAlphanumeric(char: Char) : Bool {
+    ('a' <= char and char <= 'z')
+    or
+    ('A' <= char and char <= 'Z')
+    or
+    ('0' <= char and char <= '9')
+  };
+
+  public func isAlphaNumericOr(char: Char, f : (Char) -> Bool) : Bool {
+    isAlphanumeric(char) or f(char)
+  };
+}


### PR DESCRIPTION
Add domain data structure for forward and "PTR", or reverse indexes. Simplify registrant logic in endpoints for the time being